### PR TITLE
Support automatical loading of module in Virtualhosts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ class { 'dispatcher' :
 }
 ```
 
+#### Dispatcher Loading to VirtualHosts 
+
+To automatically load the Dispatcher module into Apache Virutal hosts, the `dispatcher` class can be passed a list of those virtual host names. This will concatenate the necessary fragment into the VirtualHost conf file to allow for the dispatcher to process requests.
+
+```puppet
+class { 'dispatcher' :
+  module_file => '/path/to/module/file.so',
+  vhosts       => ['default', 'custom'],
+}
+```
+
 ### Defining a Farm
 
 The [`dispatcher::farm`] configures a render farm definition for the Dispatcher. A minimal configuration is required for successful operation - these parameters are `renderers`, `filters`, and `cache`.
@@ -181,7 +192,7 @@ dispatcher::farm { 'publish' :
       'allow' => true,
       'rank' => 10,
       'path' => { 'regex' => false, 'pattern' => '/content/*' },
-      'extension' => { 'regex' => false, 'pattern' => '.html' },
+      'extension' => { 'regex' => false, 'pattern' => 'html' },
     },
     { 'allow' => false, 'rank' => 1, 'url' => { 'regex' => true, 'pattern' => '.*' } },
   ],

--- a/examples/VirtualHost.md
+++ b/examples/VirtualHost.md
@@ -1,0 +1,14 @@
+# Virtual Host Example
+
+This example shows how to automatically load the Dispatcher module into two Apache Virutal hosts.
+
+```puppet
+  contain dispatcher
+```
+
+```yaml
+dispatcher::module_file: /path/to/dispatcher-module.so
+dispatcher::vhosts:
+  - default
+  - custom
+```

--- a/examples/farm/Filters.md
+++ b/examples/farm/Filters.md
@@ -18,5 +18,5 @@ dispatcher::farm::publish::filters:
       pattern: '/content/*'
     extension:
       regex: false
-      pattern: '.html'
+      pattern: 'html'
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,9 +179,9 @@ class dispatcher (
 
   $vhosts.each |$vhost| {
     apache::vhost::fragment { "${vhost}-dispatcher-fragment":
-      vhost     => $vhost,
-      priority  => getparam(Apache::Vhost[$vhost], 'priority'),
-      content   => $fragment
+      vhost    => $vhost,
+      priority => getparam(Apache::Vhost[$vhost], 'priority'),
+      content  => $fragment
     }
   }
 }

--- a/spec/acceptance/vhost_fragment_spec.rb
+++ b/spec/acceptance/vhost_fragment_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+#
+# Puppet Dispatcher Module - A module to manage AEM Dispatcher installations and configuration files.
+#
+# Copyright 2019 Adobe Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper_acceptance'
+require 'serverspec'
+require 'puppet_litmus'
+include PuppetLitmus
+
+dispatcher_target  = 'apache2.4'
+dispatcher_version = '4.3.3'
+dispatcher_file    = "dispatcher-#{dispatcher_target}-#{dispatcher_version}.so"
+dispatcher_tarfile = "dispatcher-#{dispatcher_target}-linux-x86_64-#{dispatcher_version}.tar.gz"
+dispatcher_src     = "http://download.macromedia.com/dispatcher/download/#{dispatcher_tarfile}"
+inventory_hash     = inventory_hash_from_inventory_file
+node_config        = facts_from_node(inventory_hash, ENV['TARGET_HOST'])
+platform           = node_config.dig('platform')
+
+case platform
+when %r{(centos|oracle|scientific)}
+  vhost_path = '/etc/httpd/conf.d'
+  service   = 'httpd'
+when %r{(debian|ubuntu)}
+  mod_path  = '/usr/lib/apache2/modules'
+  conf_path = '/etc/apache2/mods-enabled'
+  log_path  = '/var/log/apache2'
+else
+  raise 'Unknown platform.'
+end
+
+describe 'dispatcher' do
+  context 'vhost fragment' do
+    describe 'is idempotent' do
+      let(:pp) do
+        <<~PUPPETCODE
+          $dir = '/tmp/dispatcher'
+          file { $dir :
+            ensure => directory
+          }
+          archive { '#{dispatcher_tarfile}' :
+            path         => "$dir/#{dispatcher_tarfile}",
+            source       => "#{dispatcher_src}",
+            extract      => true,
+            extract_path => $dir,
+            creates      => "$dir/#{dispatcher_file}",
+            require      => File[$dir],
+          }
+          include apache
+          class { 'dispatcher' :
+            module_file => "$dir/#{dispatcher_file}",
+            vhosts      => ["default"],
+            require     => Archive['#{dispatcher_tarfile}'],
+            log_level   => 'trace',
+          }
+          dispatcher::farm { 'default' :
+            renderers => [{ hostname => 'localhost', port => 4503 }],
+            virtualhosts => ['*'],      
+            filters   => [
+              { 'allow' => false, 'rank' => 1, 'url' => { 'regex' => true, 'pattern' => '.*' }},
+              { 'allow' => true, 'rank' => 2, 'path' => { 'regex' => false, 'pattern' => '/content/*' }, 'extension' => { 'regex' => false, 'pattern' => 'html' }}
+            ],
+            cache     => {
+              docroot         => '/var/www/html',
+              rules           => [{ 'rank' => 1, 'glob' => '*.html', 'allow' => true }],
+              allowed_clients => [{ 'rank' => 1, 'glob' => '*.*.*.*', 'allow' => false }],
+            },
+          }
+        PUPPETCODE
+      end
+
+      it { expect(idempotent_apply(pp)).to be_truthy }
+    end
+    describe service(service) do
+      it { is_expected.to be_running }
+    end
+    describe file("#{vhost_path}/15-default.conf") do
+      its(:content) { is_expected.to match %r{<IfModule disp_apache2.c>$} }
+      its(:content) { is_expected.to match %r{SetHandler dispatcher-handler$} }
+      its(:content) { is_expected.to match %r{</IfModule>$} }
+    end
+    describe 'vhost loaded' do
+      it 'should block request' do
+        run_shell('curl -s -o /dev/null -w "%{http_code}" http://localhost/not/allowed') do |r|
+          expect(r.stdout).to match %r{404}
+        end
+      end
+      it 'should allow request' do
+        run_shell('curl -s -o /dev/null -w "%{http_code}" http://localhost/content/allowed.html') do |r|
+          expect(r.stdout).to match %r{502}
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/dispatcher_spec.rb
+++ b/spec/classes/dispatcher_spec.rb
@@ -250,16 +250,16 @@ describe 'dispatcher', type: :class do
       context 'vhost' do
         context 'not found' do
           let(:params) { default_params.merge(vhosts: %w[notfound]) }
+
           it { is_expected.to raise_error(%r{'-notfound.conf'}) }
         end
 
         context 'default vhost' do
           let(:params) { default_params.merge(vhosts: %w[default]) }
+
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to contain_apache__vhost__fragment(
-              'default-dispatcher-fragment'
-            ).with(
+            is_expected.to contain_apache__vhost__fragment('default-dispatcher-fragment').with(
               vhost: 'default',
               priority: catalogue.resource('Apache::Vhost[default]').parameters[:priority],
               content: '\t<IfModule disp_apache2.c>\n\t\tSetHandler dispatcher-handler\n\t </IfModule>',
@@ -283,18 +283,14 @@ describe 'dispatcher', type: :class do
 
           it { is_expected.to compile.with_all_deps }
           it do
-            is_expected.to contain_apache__vhost__fragment(
-              'default-dispatcher-fragment'
-            ).with(
+            is_expected.to contain_apache__vhost__fragment('default-dispatcher-fragment').with(
               vhost:    'default',
               priority: catalogue.resource('Apache::Vhost[default]').parameters[:priority],
               content:  '\t<IfModule disp_apache2.c>\n\t\tSetHandler dispatcher-handler\n\t </IfModule>',
             )
           end
           it do
-            is_expected.to contain_apache__vhost__fragment(
-              'custom-dispatcher-fragment'
-            ).with(
+            is_expected.to contain_apache__vhost__fragment('custom-dispatcher-fragment').with(
               vhost:    'custom',
               priority: 50,
               content:  '\t<IfModule disp_apache2.c>\n\t\tSetHandler dispatcher-handler\n\t </IfModule>',
@@ -529,13 +525,14 @@ describe 'dispatcher', type: :class do
 
       context 'farms' do
         context 'not array' do
-          let (:params) { default_params.merge(farms: 'foo') }
-          it { is_expected.to raise_error(%r{parameter 'farms' expects an Array value}) }
+          let(:params) { default_params.merge(farms: 'foo') }
 
-          context 'not string array' do
-            let (:params) { default_params.merge(farms: [123, 456]) }
-            it { is_expected.to raise_error(%r{parameter 'farms' index 1 expects a String value}) }
-          end
+          it { is_expected.to raise_error(%r{parameter 'farms' expects an Array value}) }
+        end
+        context 'not string array' do
+          let(:params) { default_params.merge(farms: [123, 456]) }
+
+          it { is_expected.to raise_error(%r{parameter 'farms' index 1 expects a String value}) }
         end
       end
 
@@ -579,13 +576,14 @@ describe 'dispatcher', type: :class do
 
       context 'vhosts' do
         context 'not array' do
-          let (:params) { default_params.merge(vhosts: 'foo') }
-          it { is_expected.to raise_error(%r{parameter 'vhosts' expects an Array value}) }
+          let(:params) { default_params.merge(vhosts: 'foo') }
 
-          context 'not string array' do
-            let (:params) { default_params.merge(vhosts: [123, 456]) }
-            it { is_expected.to raise_error(%r{parameter 'vhosts' index 1 expects a String value}) }
-          end
+          it { is_expected.to raise_error(%r{parameter 'vhosts' expects an Array value}) }
+        end
+        context 'not string array' do
+          let(:params) { default_params.merge(vhosts: [123, 456]) }
+
+          it { is_expected.to raise_error(%r{parameter 'vhosts' index 1 expects a String value}) }
         end
       end
     end

--- a/spec/classes/dispatcher_spec.rb
+++ b/spec/classes/dispatcher_spec.rb
@@ -262,7 +262,7 @@ describe 'dispatcher', type: :class do
             is_expected.to contain_apache__vhost__fragment('default-dispatcher-fragment').with(
               vhost: 'default',
               priority: catalogue.resource('Apache::Vhost[default]').parameters[:priority],
-              content: '\t<IfModule disp_apache2.c>\n\t\tSetHandler dispatcher-handler\n\t </IfModule>',
+              content: "\n  <IfModule disp_apache2.c>\n    SetHandler dispatcher-handler\n  </IfModule>\n\n",
             )
           end
         end
@@ -286,14 +286,14 @@ describe 'dispatcher', type: :class do
             is_expected.to contain_apache__vhost__fragment('default-dispatcher-fragment').with(
               vhost:    'default',
               priority: catalogue.resource('Apache::Vhost[default]').parameters[:priority],
-              content:  '\t<IfModule disp_apache2.c>\n\t\tSetHandler dispatcher-handler\n\t </IfModule>',
+              content: "\n  <IfModule disp_apache2.c>\n    SetHandler dispatcher-handler\n  </IfModule>\n\n",
             )
           end
           it do
             is_expected.to contain_apache__vhost__fragment('custom-dispatcher-fragment').with(
               vhost:    'custom',
               priority: 50,
-              content:  '\t<IfModule disp_apache2.c>\n\t\tSetHandler dispatcher-handler\n\t </IfModule>',
+              content: "\n  <IfModule disp_apache2.c>\n    SetHandler dispatcher-handler\n  </IfModule>\n\n",
             )
           end
         end

--- a/spec/type_aliases/farm/filter_spec.rb
+++ b/spec/type_aliases/farm/filter_spec.rb
@@ -25,7 +25,7 @@ describe 'Dispatcher::Farm::Filter' do
     [
       { allow: true, rank: 0 },
       { allow: true, rank: 10, method: { regex: true, pattern: 'GET' } },
-      { allow: true, rank: 10, url: { regex: true, pattern: '*.html' } },
+      { allow: true, rank: 10, url: { regex: true, pattern: 'html' } },
       { allow: true, rank: 10, query: { regex: true, pattern: 'param=value' } },
       { allow: true, rank: 10, protocol: { regex: true, pattern: 'http' } },
       { allow: true, rank: 10, path: { regex: true, pattern: '/content/test/en' } },


### PR DESCRIPTION
## Description

Automatically load the dispatcher module when requested by specified parameter.

## Related Issue

[VirtualHost support](#4)

## Motivation and Context

Incorporate as much management of adding a dispatcher to Apache into this module as possible.

## How Has This Been Tested?

Full Spec & Acceptance tests added.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.