### PR TITLE
Support SELinux on the docroot for a farm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,34 @@ Adobe Security best practices recommend that only explicit agents be allowed to 
 }
 ```
 
+### SELinux Docroot Support
+
+Normally the Apache module is responsible for managing the *docroot* for a given farm and VirtualHost. However, when SELinux is enabled and enforcing, this creates an issue as the default setting for the *docroot* is read only.
+
+This module allows you to switch ownership of the docroot from the Apache module to this module. Thus, when SELinux is enforcing, the `seltype` will be correctly set to read/write on this folder. To do so, set the `manage_docroot` of the `Dispatcher::Farm::Cache` struct to `true`. 
+
+> **Note**: The [`manage_docroot`](https://github.com/puppetlabs/puppetlabs-apache/blob/master/REFERENCE.md#manage_docroot) of the Apache VirtualHost resource must be set to `false` or a catalog error will occur. 
+
+```puppet
+dispatcher::farm { 'publish' :
+...
+  cache => {
+    docroot => '/var/www/html',
+    manage_docroot => true,
+    rules => [
+      { rank => 1, glob => '*.html', allow => true },
+    ],
+    allowed_clients => [
+      { rank => 1, glob => '*', allow => false },
+      { rank => 2, glob => '127.0.0.1', allow => true },
+    ],
+  }
+...
+}
+``` 
+
+> **Note**: This module only supports managing the `docroot` based on default parameters in the Apache module. To customize further, the `docroot` must be managed externally.  
+
 ## Reference
 
 For information on classes, types, and structs see the [REFERENCE.md][].

--- a/examples/farm/cache/ManageDocroot.md
+++ b/examples/farm/cache/ManageDocroot.md
@@ -1,0 +1,23 @@
+# Cache Auto Manage Docroot Farm Example
+
+This example will configure the farm to manage the docroot instead of Apache's virtual host resource.
+
+```yaml
+dispatcher::farm::publish::cache:
+  docroot: /path/to/docroot
+  manage_docroot: true
+  rules:
+    -
+      rank: 1
+      glob: '*.html'
+      allow: true
+  allowed_clients:
+    -
+      rank: 1
+      glob: '*'
+      allow: false
+    -
+      rank: 2
+      glob: '127.0.0.1'
+      allow: true
+```

--- a/manifests/farm.pp
+++ b/manifests/farm.pp
@@ -195,6 +195,18 @@ define dispatcher::farm (
     $_priority = $priority
   }
 
+  if ($cache['manage_docroot']) {
+    file { $cache['docroot'] :
+      owner => 'root',
+      group => $::apache::params::root_group,
+    }
+    if $facts['selinux_enforced'] {
+      File[$cache['docroot']] {
+        seltype => 'httpd_sys_rw_content_t',
+      }
+    }
+  }
+
   if ($secure) {
     $_secure_cache = lookup('dispatcher::farm::cache::secured', Hash, 'deep', {})
     $_cache_tmp = {

--- a/spec/acceptance/cache_docroot_spec.rb
+++ b/spec/acceptance/cache_docroot_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#
+# Puppet Dispatcher Module - A module to manage AEM Dispatcher installations and configuration files.
+#
+# Copyright 2019 Adobe Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper_acceptance'
+require 'serverspec'
+require 'puppet_litmus'
+include PuppetLitmus
+
+dispatcher_target  = 'apache2.4'
+dispatcher_version = '4.3.3'
+dispatcher_file    = "dispatcher-#{dispatcher_target}-#{dispatcher_version}.so"
+dispatcher_tarfile = "dispatcher-#{dispatcher_target}-linux-x86_64-#{dispatcher_version}.tar.gz"
+dispatcher_src     = "http://download.macromedia.com/dispatcher/download/#{dispatcher_tarfile}"
+inventory_hash     = inventory_hash_from_inventory_file
+node_config        = facts_from_node(inventory_hash, ENV['TARGET_HOST'])
+platform           = node_config.dig('platform')
+
+case platform
+when %r{(centos|oracle|scientific)}
+  service   = 'httpd'
+when %r{(debian|ubuntu)}
+  service   = 'apache2'
+else
+  raise 'Unknown platform.'
+end
+
+describe 'dispatcher' do
+  context 'cache docroot' do
+    describe 'is idempotent' do
+      let(:pp) do
+        <<~PUPPETCODE
+          $dir = '/tmp/dispatcher'
+          file { $dir :
+            ensure => directory
+          }
+          archive { '#{dispatcher_tarfile}' :
+            path         => "$dir/#{dispatcher_tarfile}",
+            source       => "#{dispatcher_src}",
+            extract      => true,
+            extract_path => $dir,
+            creates      => "$dir/#{dispatcher_file}",
+            require      => File[$dir],
+          }
+          class { 'apache' :
+            default_vhost     => false,
+            default_ssl_vhost => false,
+          }
+          apache::vhost { 'managedocroot' :
+            port           => '80',
+            default_vhost  => true,
+            docroot        => '/var/www/html',
+            manage_docroot => false,
+          }
+          class { 'dispatcher' :
+            module_file => "$dir/#{dispatcher_file}",
+            require     => Archive['#{dispatcher_tarfile}']
+          }
+          dispatcher::farm { 'default' :
+            renderers => [{ hostname => 'localhost', port => 4503 }],
+            filters   => [{ 'allow' => false, 'rank' => 1, 'url' => { 'regex' => true, 'pattern' => '.*' }}],
+            cache     => {
+              docroot         => '/var/www/html',
+              manage_docroot  => true,
+              rules           => [{ 'rank' => 1, 'glob' => '*.html', 'allow' => true }],
+              allowed_clients => [{ 'rank' => 1, 'glob' => '*.*.*.*', 'allow' => false }],
+            },
+          }
+        PUPPETCODE
+      end
+
+      it { expect(idempotent_apply(pp)).to be_truthy }
+    end
+    describe service(service) do
+      it { is_expected.to be_running }
+    end
+  end
+end

--- a/spec/acceptance/default_params_spec.rb
+++ b/spec/acceptance/default_params_spec.rb
@@ -42,6 +42,7 @@ when %r{(debian|ubuntu)}
   mod_path  = '/usr/lib/apache2/modules'
   conf_path = '/etc/apache2/mods-enabled'
   log_path  = '/var/log/apache2'
+  service   = 'apache2'
 else
   raise 'Unknown platform.'
 end

--- a/spec/acceptance/secure_params_spec.rb
+++ b/spec/acceptance/secure_params_spec.rb
@@ -38,6 +38,7 @@ when %r{(debian|ubuntu)}
   mod_path  = '/usr/lib/apache2/modules'
   conf_path = '/etc/apache2/mods-enabled'
   log_path  = '/var/log/apache2'
+  service   = 'apache2'
   ssl_version = '1.1'
 else
   raise 'Unknown platform.'

--- a/spec/data/managedocroot.yaml
+++ b/spec/data/managedocroot.yaml
@@ -1,0 +1,49 @@
+#
+# Puppet Dispatcher Module - A module to manage AEM Dispatcher installations and configuration files.
+#
+# Copyright 2019 Adobe Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+dispatcher::decline_root: true
+dispatcher::log_file: "%{::apache::logroot}/dispatcher.log"
+dispatcher::log_level: 'warn'
+dispatcher::pass_error: false
+dispatcher::use_processed_url: true
+
+dispatcher::farm::managedocroot::renderers:
+  -
+    hostname: localhost
+    port: 4503
+dispatcher::farm::managedocroot::filters:
+  -
+    allow: false
+    rank: 01
+    url:
+      regex: true
+      pattern: '.*'
+dispatcher::farm::managedocroot::cache:
+  docroot: /path/to/docroot
+  manage_docroot: true
+  rules:
+    -
+      rank: 1
+      glob: '*.html'
+      allow: true
+  allowed_clients:
+    -
+      rank: 1
+      glob: '*.*.*.*'
+      allow: false

--- a/spec/defines/farm/cache_fragment_spec.rb
+++ b/spec/defines/farm/cache_fragment_spec.rb
@@ -95,6 +95,26 @@ describe 'dispatcher::farm', type: :define do
           it { is_expected.to contain_concat__fragment('secure-farm-cache').with(content: %r{^\s{6}/0000 \{ /type "deny" /glob "\*" \}$}) }
           it { is_expected.to contain_concat__fragment('secure-farm-cache').with(content: %r{^\s{6}/0001 \{ /type "allow" /glob "127\.0\.0\.1" \}$}) }
         end
+        context 'manage docroot' do
+          let(:facts) { os_facts.merge(testname: 'managedocroot') }
+          let(:title) { 'managedocroot' }
+
+          it { is_expected.to contain_file('/path/to/docroot').with(owner: 'root', group: 'root') }
+
+          context 'selinux' do
+            let(:facts) { os_facts.merge(testname: 'managedocroot', selinux_enforced: true) }
+            let(:title) { 'managedocroot' }
+
+            it { is_expected.to contain_file('/path/to/docroot').with(owner: 'root', group: 'root', seltype: 'httpd_sys_rw_content_t') }
+            it { is_expected.to contain_concat('dispatcher.00-managedocroot.inc.any') }
+            it { is_expected.to contain_concat__fragment('managedocroot-farm-header') }
+            it { is_expected.to contain_concat__fragment('managedocroot-farm-renders') }
+            it { is_expected.to contain_concat__fragment('managedocroot-farm-virtualhosts') }
+            it { is_expected.to contain_concat__fragment('managedocroot-farm-cache') }
+            it { is_expected.to contain_concat__fragment('managedocroot-farm-filter') }
+            it { is_expected.to contain_concat__fragment('managedocroot-farm-footer') }
+          end
+        end
       end
     end
   end

--- a/spec/type_aliases/farm/cache_spec.rb
+++ b/spec/type_aliases/farm/cache_spec.rb
@@ -34,6 +34,18 @@ describe 'Dispatcher::Farm::Cache' do
         allowed_clients: [{ rank: 1, glob: '*.*.*.*', allow: false }, { rank: 20, glob: '127.0.0.1', allow: true }],
       },
       {
+        docroot:              '/path/to/docroot',
+        rules:                [{ rank: 1, glob: '*.html', allow: true }],
+        allowed_clients:      [{ rank: 1, glob: '*.*.*.*', allow: false }],
+        manage_docroot:       true,
+      },
+      {
+        docroot:              '/path/to/docroot',
+        rules:                [{ rank: 1, glob: '*.html', allow: true }],
+        allowed_clients:      [{ rank: 1, glob: '*.*.*.*', allow: false }],
+        manage_docroot:       false,
+      },
+      {
         docroot:         '/path/to/docroot',
         rules:           [{ rank: 1, glob: '*.html', allow: true }],
         allowed_clients: [{ rank: 1, glob: '*.*.*.*', allow: false }],
@@ -159,6 +171,12 @@ describe 'Dispatcher::Farm::Cache' do
         docroot:         'invalid',
         rules:           [{ rank: 1, glob: '*.html', allow: true }],
         allowed_clients: [{ rank: 1, glob: '*.*.*.*', allow: false }],
+      },
+      {
+        docroot:              '/path/to/docroot',
+        rules:                [{ rank: 1, glob: '*.html', allow: true }],
+        allowed_clients:      [{ rank: 1, glob: '*.*.*.*', allow: false }],
+        manage_docroot:       'invalid',
       },
       {
         docroot:         '/path/to/docroot',

--- a/types/farm/cache.pp
+++ b/types/farm/cache.pp
@@ -26,6 +26,7 @@
 #  - docroot:               `StdLib::Absolutepath`
 #  - rules:                 `Array[Dispatcher::Farm::GlobRule]`
 #  - allowed_clients:       `Array[Dispatcher::Farm::GlobRule]`
+#  - manage_docroot         `Boolean`
 #  - statfile               `Stdlib::Absolutepath`
 #  - serve_stale_on_error:  `Boolean`
 #  - allow_authorized       `Boolean`
@@ -43,6 +44,7 @@ type Dispatcher::Farm::Cache = Struct[
     docroot                        => Stdlib::Absolutepath,
     rules                          => Array[Dispatcher::Farm::GlobRule],
     allowed_clients                => Array[Dispatcher::Farm::GlobRule],
+    Optional[manage_docroot]       => Boolean,
     Optional[statfile]             => Stdlib::Absolutepath,
     Optional[serve_stale_on_error] => Boolean,
     Optional[allow_authorized]     => Boolean,


### PR DESCRIPTION
## Description

Allow for managing the document root as part of the farm. When SELinux is enabled, the correct read/write flag can be set on the `seltype` to allow the dispatcher to work

## Related Issue

[Manage Docroot](#8)

## Motivation and Context

Further reduce external management of resources to achieve necessary capabilities.

## How Has This Been Tested?

Full rspec tests and added acceptance tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.